### PR TITLE
Contribution from UK NOC - eORCA025 & eORCA12

### DIFF
--- a/Dataset_NOC_eORCA025_ERA5v1/Dataset_NOC_eORCA025_ERA5v1.yaml
+++ b/Dataset_NOC_eORCA025_ERA5v1/Dataset_NOC_eORCA025_ERA5v1.yaml
@@ -41,7 +41,7 @@ NOC_eORCA12_ERA5v1: # MODEL NAMES
         sea_ice_model : "SI3" # None or name of the sea ice model codebase        
         lateral_boundary_condition : "None" # None or reference of the forcing dataset
         lateral_boundary_condition_frequency : "None" # None or frequency of forcing dataset
-        river_runoff_dataset:  "Bourdallé-Badie, R. and Treguier, A.2006 climatolog; Rignot et al., 2013 ice shelf melt climatology" # None or reference to the database
+        river_runoff_dataset:  "Bourdallé-Badie, R. and Treguier, A.2006 climatology; Rignot et al., 2013 ice shelf melt climatology" # None or reference to the database
         tidal_constituents: "None" # “None” or list of constituents        
       ## Detail on model schemes and parameters   
       model_parameters:

--- a/Dataset_NOC_eORCA12_ERA5v1/Dataset_NOC_eORCA12_ERA5v1.yaml
+++ b/Dataset_NOC_eORCA12_ERA5v1/Dataset_NOC_eORCA12_ERA5v1.yaml
@@ -8,11 +8,11 @@ NOC_eORCA12_ERA5v1: # MODEL NAMES
       model_information:
         simulation_name: "NPD eORCA12 ERA-5 version 1"
         simulation_codebase: "NEMO"
-        codebase_version: "4.2"
+        codebase_version: "4.2.2"
       ## Information about the model dataset 
       model_dataset:
         output_frequency: "24" #  in h
-        type_of_average : "averaging" #  ‘None’ or averaging frequency in h
+        type_of_average : "24" #  ‘None’ or averaging frequency in h
         model_year: "2024" # Remember, just one year for metadata and dataset. If you wish to contribute more than one year, please complete this file for each year.
         base_s3_folder: "s3://npd-eorca12-era5v1-swot-omip/" # Access S3 point
         endpoint_url: "https://noc-msm-o.s3-ext.jc.rl.ac.uk"


### PR DESCRIPTION
Added metadata .yaml files for UK NOC contribution to SWOT-OMIP:

- [x] `Dataset_NOC_eORCA025_ERA5v1/Dataset_NOC_eORCA025_ERA5v1.yaml `
- [x] `Dataset_NOC_eORCA12_ERA5v1/Dataset_NOC_eORCA12_ERA5v1.yaml`

Both contributions use the **synthocean** `pyinterp` option to perform interpolation using daily mean model outputs for 2024.

Resulting `.nc` files have been made available (read-only public access) in the same structure as the 2024 SWOT global grid data files provided & can be either downloaded from the object store or read via https using xarray, for example: 

```python
xr.open_dataset("https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca12-era5v1-swot-omip/cycle_008/eORCA12_ERA5v1_SWOT_SSH_008_497_20240101T000706_20240101T005832_v1.0.2.nc#mode=bytes")
```